### PR TITLE
Support non /24 netmasks via the options file

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -167,3 +167,12 @@ func getTableRoutes(ifidx int, table int) ([]*net.IPNet, error) {
 	}
 	return r, nil
 }
+
+// Determine the gateway based on IP and Netmask.
+func gatewayFromIP(ipnet *net.IPNet) *net.IP {
+	// Apply netmask to IP, then increment last octet by one
+	gw := ipnet.IP.Mask(ipnet.Mask)
+	gw[len(gw)-1] += 1
+
+	return &gw
+}

--- a/helper_test.go
+++ b/helper_test.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func IPsEqual(a, b []net.IP) bool {
@@ -118,5 +120,28 @@ func TestGetHostnameOverride(t *testing.T) {
 				t.Logf("Success !")
 			}
 		})
+	}
+}
+
+func TestGatewayFromIP(t *testing.T) {
+	tests := []struct {
+		input  string
+		output string
+	}{
+		{"192.168.11.11/23", "192.168.10.1"},
+		{"192.168.14.15/24", "192.168.14.1"},
+		{"192.168.11.40/27", "192.168.11.33"},
+	}
+
+	for _, test := range tests {
+		ip, ipnet, err := net.ParseCIDR(test.input)
+		assert.Nil(t, err, "Failed to parse test data!")
+		chosenIP := net.IPNet{
+			IP:   ip,
+			Mask: ipnet.Mask,
+		}
+		gw := gatewayFromIP(&chosenIP)
+
+		assert.Equal(t, test.output, gw.String(), "Unexpected gateway")
 	}
 }

--- a/listener.go
+++ b/listener.go
@@ -204,11 +204,11 @@ func (l *Listener) handleMsg(buf []byte, oob *ipv4.ControlMessage, _peer net.Add
 
 	l.log.Debugf("Picked IP: %v", pickedIP)
 
-	// the default gateway handed out by DHCP is the .1 of whatever /24 subnet the client gets handed out.
+	// the default gateway handed out by DHCP is the first IP of whatever subnet the client gets handed out.
 	// we actually don't care at all what the gw IP is, its really just to make the client's tcp/ip stack happy
 	if options.Gateway == nil {
-		gw := net.IPv4(pickedIP.IP[0], pickedIP.IP[1], pickedIP.IP[2], 1)
-		options.Gateway = &gw
+		gw := gatewayFromIP(pickedIP)
+		options.Gateway = gw
 	}
 
 	// source IP to be sending from

--- a/options/options.go
+++ b/options/options.go
@@ -63,6 +63,13 @@ func parseIP(log *ll.Entry, ipstr string) (*net.IPNet, error) {
 	// Parse as CIDR
 	ip, ipnet, err := net.ParseCIDR(ipstr)
 	if err == nil {
+		// Reject prefixes > 29 as they're nonsensical and we cannot derive a
+		// gateway IP from them.
+		ones, _ := ipnet.Mask.Size()
+		if ones > 29 {
+			return nil, fmt.Errorf("%s has an unusable prefix of %d", ipstr, ones)
+		}
+
 		log.Infof("Parsed successfully as CIDR: %s", ipstr)
 		// Use IPNet to store the actual IP and netmask
 		ret := net.IPNet{

--- a/options/options.go
+++ b/options/options.go
@@ -16,17 +16,18 @@ import (
 // set. Likewise if it cannot be parsed (this will result in a warning being
 // logged).
 type dhcpJSON struct {
-	IPv4       []string
+	IPv4       []string // Address/Prefix. If not specified, Prefix is implicitly /24
 	Hostname   string
 	Domainname string
-	Gateway    string
-	PvtIPs     string // Must be CIDR
+	Gateway    string // Address
+	PvtIPs     string // Address/Prefix
 	Tftp       string
 }
 
 // This struct represents the parsed DHCP options as used internally.
 type DHCP struct {
-	IPv4 []net.IP
+	// If empty, these aren't set
+	IPv4 []*net.IPNet
 
 	// If nil, these aren't set.
 	Hostname   *string
@@ -57,6 +58,33 @@ func Load(log *ll.Entry, filepath string) (*DHCP, error) {
 	return parse(log, bytes)
 }
 
+// Parse a string as a CIDR or as an IP with implicit /24 prefix.
+func parseIP(log *ll.Entry, ipstr string) (*net.IPNet, error) {
+	// Parse as CIDR
+	ip, ipnet, err := net.ParseCIDR(ipstr)
+	if err == nil {
+		log.Infof("Parsed successfully as CIDR: %s", ipstr)
+		// Use IPNet to store the actual IP and netmask
+		ret := net.IPNet{
+			IP:   ip,
+			Mask: ipnet.Mask,
+		}
+		return &ret, nil
+	}
+
+	// Fall back to parsing as IP
+	ip = net.ParseIP(ipstr)
+	if ip == nil {
+		return nil, fmt.Errorf("failed to parse %s as IP", ipstr)
+	}
+
+	ret := net.IPNet{
+		IP:   ip,
+		Mask: net.CIDRMask(24, 32),
+	}
+	return &ret, nil
+}
+
 func parse(log *ll.Entry, bytes []byte) (*DHCP, error) {
 	options := &DHCP{}
 	var onDisk dhcpJSON
@@ -66,12 +94,12 @@ func parse(log *ll.Entry, bytes []byte) (*DHCP, error) {
 	}
 
 	for _, ipstr := range onDisk.IPv4 {
-		ip := net.ParseIP(ipstr)
-		if ip == nil {
-			ll.Warnf("Failed to parse IP=%s, it will be ignored", ipstr)
-			continue
+		ipnet, err := parseIP(log, ipstr)
+		if err == nil {
+			options.IPv4 = append(options.IPv4, ipnet)
+		} else {
+			log.Warnf("Failed to parse IP=%s, it will be ignored: %v", ipstr, err)
 		}
-		options.IPv4 = append(options.IPv4, ip)
 	}
 
 	if onDisk.Hostname != "" {

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -25,7 +25,7 @@ func TestNoFile(t *testing.T) {
 func TestParse(t *testing.T) {
 	json := `
 {
-  "IPv4":       ["1.1.1.1", "invalid-will-be-skipped", "2.2.2.2"],
+  "IPv4":       ["1.1.1.1/23", "invalid-will-be-skipped", "2.2.2.2"],
   "hostname":   "myhostname",
   "domainname": "domain",
   "gateway":    "1.2.3.4",
@@ -39,8 +39,8 @@ func TestParse(t *testing.T) {
 	assert.Nil(t, err, "Failed to load options")
 
 	assert.Equal(t, 2, len(options.IPv4))
-	assert.Equal(t, "1.1.1.1", options.IPv4[0].String(), "Bad first IP")
-	assert.Equal(t, "2.2.2.2", options.IPv4[1].String(), "Bad second IP")
+	assert.Equal(t, "1.1.1.1/23", options.IPv4[0].String(), "Bad first IP")
+	assert.Equal(t, "2.2.2.2/24", options.IPv4[1].String(), "Bad second IP")
 	assert.Equal(t, "myhostname", *options.Hostname, "Bad Hostname")
 	assert.Equal(t, "domain", *options.Domainname, "Bad Domainname")
 	assert.Equal(t, "1.2.3.4", options.Gateway.To4().String(), "Bad Gateway")
@@ -48,4 +48,26 @@ func TestParse(t *testing.T) {
 	mask := net.IPv4Mask(255, 255, 255, 0)
 	assert.Equal(t, mask.String(), options.PvtIPs.Mask.String(), "Bad PvtIPs")
 	assert.Equal(t, "3.4.5.6", options.Tftp.String(), "Bad Tftp")
+}
+
+// Test parsing of IP and prefix
+func TestParseIP(t *testing.T) {
+	log := ll.NewEntry(ll.StandardLogger())
+	// Error
+	_, err := parseIP(log, "blah")
+	assert.NotEqual(t, err, nil)
+
+	// Invalid prefix
+	_, err = parseIP(log, "1.2.3.4/4444")
+	assert.NotNil(t, err)
+
+	// IP, /24 implicit
+	ipnet, err := parseIP(log, "192.168.100.1")
+	assert.Nil(t, err)
+	assert.Equal(t, ipnet.String(), "192.168.100.1/24")
+
+	// Subnet specified
+	ipnet, err = parseIP(log, "10.53.1.2/25")
+	assert.Nil(t, err)
+	assert.Equal(t, ipnet.String(), "10.53.1.2/25")
 }

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -57,10 +57,6 @@ func TestParseIP(t *testing.T) {
 	_, err := parseIP(log, "blah")
 	assert.NotEqual(t, err, nil)
 
-	// Invalid prefix
-	_, err = parseIP(log, "1.2.3.4/4444")
-	assert.NotNil(t, err)
-
 	// IP, /24 implicit
 	ipnet, err := parseIP(log, "192.168.100.1")
 	assert.Nil(t, err)
@@ -70,4 +66,28 @@ func TestParseIP(t *testing.T) {
 	ipnet, err = parseIP(log, "10.53.1.2/25")
 	assert.Nil(t, err)
 	assert.Equal(t, ipnet.String(), "10.53.1.2/25")
+
+	ipnet, err = parseIP(log, "10.53.1.2/29")
+	assert.Nil(t, err)
+	assert.Equal(t, ipnet.String(), "10.53.1.2/29")
+
+	// Prefixes that are technically valid, but not usable
+	ipnet, err = parseIP(log, "10.53.1.2/30")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "has an unusable prefix")
+	}
+
+	ipnet, err = parseIP(log, "10.53.1.2/32")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "has an unusable prefix")
+	}
+
+	// Invalid prefixes
+	_, err = parseIP(log, "1.2.3.4/4444")
+	assert.NotNil(t, err)
+
+	ipnet, err = parseIP(log, "10.53.1.2/33")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "failed to parse")
+	}
 }


### PR DESCRIPTION
This PR adds support for netmasks that are not /24. This is essentially implemented by managing IPs as `net.IPNet` (address + mask) instead of plain `net.IP`. Whenever a CIDR-less IP is encountered, a /24 is implicitly generated, so the changes remain backwards compatible.

The PR also includes a couple of bug fixes, see inline PR comments.