### PR TITLE
Change default dns resolvers, if none are specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func main() {
 	ll.Infof("ignoring private IPs from %v", pvtIPs)
 
 	if len(myDNS) == 0 {
-		err := myDNS.Set("1.1.1.1")
+		err := myDNS.Set("8.8.8.8")
 		if err != nil {
 			ll.Fatalln("failed to set default DNS server")
 		}


### PR DESCRIPTION
Just changing the default value of DNS if -dns flag is not specified.
All unit tests pass.

Ticket with context: [CLIC-1167](https://track.akamai.com/jira/browse/CLIC-1167)