### PR TITLE
Clean up of warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,14 +8,14 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.6.1
 	github.com/vishvananda/netlink v1.1.0
+	github.com/vishvananda/netns v0.0.4
 	golang.org/x/net v0.0.0-20211020060615-d418f374d309
+	golang.org/x/sys v0.2.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/u-root/uio v0.0.0-20210528151154-e40b768296a7 // indirect
-	github.com/vishvananda/netns v0.0.4 // indirect
-	golang.org/x/sys v0.2.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/linode/dhcpd-unnumbered
 
-go 1.17
+go 1.23.1
 
 require (
 	github.com/google/gopacket v1.1.19

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/u-root/uio v0.0.0-20210528151154-e40b768296a7/go.mod h1:LpEX5FO/cB+WF
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvVn1ZaTIVp+3vuYAXFe3OJEvjbUYJLaA=
-github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -76,15 +74,12 @@ golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201101102859-da207088b7d1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
-golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/go.sum
+++ b/go.sum
@@ -77,15 +77,11 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201101102859-da207088b7d1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=

--- a/helper_test.go
+++ b/helper_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -86,7 +85,7 @@ func overrideFile(t *testing.T, ifName, hostname string) {
 	*flagHostnamePath = "/tmp/"
 
 	s := []byte(hostname)
-	ioutil.WriteFile(*flagHostnamePath+ifName, s, 0644)
+	os.WriteFile(*flagHostnamePath+ifName, s, 0644)
 
 	t.Cleanup(func() {
 		os.Remove(*flagHostnamePath + ifName)

--- a/listener.go
+++ b/listener.go
@@ -15,7 +15,7 @@ import (
 
 // This is returned if NewListener is called with a specified interface, that's
 // not a VRF.
-var ErrNotVRF = errors.New("Not a VRF interface")
+var ErrNotVRF = errors.New("not a VRF interface")
 
 // Listener is the core struct
 type Listener struct {
@@ -86,14 +86,14 @@ func (l *Listener) Listen() error {
 	l.log.Infof("Listen %s", l.c.LocalAddr())
 	for {
 		b := make([]byte, MaxDatagram)
-		n, oob, peer, err := l.c.ReadFrom(b)
+		n, oob, _, err := l.c.ReadFrom(b)
 		if err != nil {
 			// NOTE: this error will also be logged if the socket is closed when
 			// the VRF disappears (which is expected).
 			l.log.Errorf("Error reading from connection: %v (this error is expected if a VRF was torn down)", err)
 			return err
 		}
-		go l.handleMsg(b[:n], oob, peer.(*net.UDPAddr))
+		go l.handleMsg(b[:n], oob)
 	}
 }
 
@@ -103,7 +103,7 @@ func (l *Listener) Close() error {
 }
 
 // handleMsg is triggered every time there is a DHCP request coming in. this is the main deal handling the reply
-func (l *Listener) handleMsg(buf []byte, oob *ipv4.ControlMessage, _peer net.Addr) {
+func (l *Listener) handleMsg(buf []byte, oob *ipv4.ControlMessage) {
 	ifi, err := net.InterfaceByIndex(oob.IfIndex)
 	if err != nil {
 		l.log.Errorf("Error getting request interface: %v", err)

--- a/main.go
+++ b/main.go
@@ -128,6 +128,9 @@ func main() {
 
 	// Listen across interfaces with a single socket
 	s, err := NewListener("")
+	if err != nil {
+		ll.Errorf("new instance of DHCP listener couldn't be created: %v", err)
+	}
 	s.SetSource(sIP)
 	wg.Add(1)
 	go func() {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"regexp"
 	"sync"
@@ -53,7 +53,7 @@ var (
 	flagBootfile   = flag.String("bootfile", "", "boot file to offer in DHCP replies")
 
 	logLevels = map[string]func(){
-		"none":    func() { ll.SetOutput(ioutil.Discard) },
+		"none":    func() { ll.SetOutput(io.Discard) },
 		"trace":   func() { ll.SetLevel(ll.TraceLevel) },
 		"debug":   func() { ll.SetLevel(ll.DebugLevel) },
 		"info":    func() { ll.SetLevel(ll.InfoLevel) },


### PR DESCRIPTION
Remove unused parameter for clarity. Check unchecked error. Uncapitalize error log.
Bumping of go version to 1.23.1. Tidy go.mod and go.sum.

Ticket: https://track.akamai.com/jira/browse/CRSKRK-81